### PR TITLE
Update angular2 dependencies and d3-voronoi

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d3-ng2-service",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "A D3 version 4 service for use with Angular 2.",
   "main": "index.js",
   "jsnext:main": "esm/index.js",
@@ -88,7 +88,7 @@
     "@types/d3-time-format": "2.0",
     "@types/d3-timer": "1.0",
     "@types/d3-transition": "1.0",
-    "@types/d3-voronoi": "1.0",
+    "@types/d3-voronoi": "1.1",
     "@types/d3-zoom": "1.0",
     "d3-array": "1.0",
     "d3-axis": "1.0",
@@ -118,21 +118,22 @@
     "d3-time-format": "2.0",
     "d3-timer": "1.0",
     "d3-transition": "1.0",
-    "d3-voronoi": "1.0",
+    "d3-voronoi": "1.1",
     "d3-zoom": "1.0"
   },
   "peerDependencies": {
-    "@angular/core": "2.0 || 2.0.0-rc.5 || 2.0.0-rc.6 || 2.0.0-rc.7"
+    "@angular/core": "^2.0 || 2.0.0-rc.5 || 2.0.0-rc.6 || 2.0.0-rc.7"
   },
   "devDependencies": {
-    "@angular/core": "2.0.0",
-    "codelyzer": "0.0.28",
+    "@angular/compiler": "2.1.2",
+    "@angular/core": "2.1.0",
+    "codelyzer": "1.0.0-beta.3",
     "grunt": "^1.0.1",
     "grunt-ts": "6.0.0-beta.3",
     "grunt-tslint": "^3.2.1",
     "rxjs": "5.0.0-beta.12",
     "tslint": "^3.15.1",
     "typescript": "^2.0.2",
-    "zone.js": "^0.6.21"
+    "zone.js": "^0.6.23"
   }
 }

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
   },
   "devDependencies": {
     "@angular/compiler": "2.1.2",
-    "@angular/core": "2.1.0",
+    "@angular/core": "2.1.2",
     "codelyzer": "1.0.0-beta.3",
     "grunt": "^1.0.1",
     "grunt-ts": "6.0.0-beta.3",


### PR DESCRIPTION
* Closes #15
* Closes #16
* Closes #18 

Minor version bumped due to inclusion on new d3-voronoi method (`find(...)` on `VoronoiDiagram`)