### PR TITLE
1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d3-ng2-service",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "A D3 version 4 service for use with Angular 2.",
   "main": "index.js",
   "jsnext:main": "esm/index.js",
@@ -89,7 +89,7 @@
     "@types/d3-timer": "1.0",
     "@types/d3-transition": "1.0",
     "@types/d3-voronoi": "1.1",
-    "@types/d3-zoom": "1.0",
+    "@types/d3-zoom": "1.1",
     "d3-array": "1.0",
     "d3-axis": "1.0",
     "d3-brush": "1.0",
@@ -119,7 +119,7 @@
     "d3-timer": "1.0",
     "d3-transition": "1.0",
     "d3-voronoi": "1.1",
-    "d3-zoom": "1.0"
+    "d3-zoom": "1.1"
   },
   "peerDependencies": {
     "@angular/core": "^2.0 || 2.0.0-rc.5 || 2.0.0-rc.6 || 2.0.0-rc.7"


### PR DESCRIPTION
* Update d3-zoom to pinned version 1.1 By implication the modules within the scope of the service now correspond to D3 v4 (with the exception of the out-of-scope d3-request)

Addresses issue #25 