### PR TITLE
1.5.2

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -61,7 +61,9 @@ export {
   DSVRowAny,
   DSVRowString,
   // d3-ease
-  // no Interfaces to export
+  BackEasingFactory,
+  ElasticEasingFactory,
+  PolynomialEasingFactory,
   // d3-force
   Force,
   ForceCenter,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d3-ng2-service",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "A D3 version 4 service for use with Angular 2.",
   "main": "index.js",
   "jsnext:main": "esm/index.js",


### PR DESCRIPTION
* Patch release implicitly uses latest fixed definitions for d3-ease (@types version 1.0.5 which includes additional interfaces for parameterized easing function factories (`back`, `poly` and `elastic`)