### PR TITLE
missing d3-request

### DIFF
--- a/src/bundle-d3.ts
+++ b/src/bundle-d3.ts
@@ -18,6 +18,7 @@ export * from 'd3-polygon';
 export * from 'd3-quadtree';
 export * from 'd3-queue';
 export * from 'd3-random';
+export * from 'd3-request';
 export * from 'd3-scale';
 export * from 'd3-selection';
 export * from 'd3-selection-multi';


### PR DESCRIPTION
From what I noticed in d3 (v4.4.4), I think the `d3-request` is missing.
Cheers