### PR TITLE
fix(bundle): work with ES2015-aware bundlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.8.0",
   "description": "A D3 version 4 service for use with Angular 2.",
   "main": "index.js",
+  "module": "index.js",
   "jsnext:main": "esm/index.js",
   "typings": "index.d.ts",
   "scripts": {


### PR DESCRIPTION
I think `jsnext:main` is incorrectly pointing to an ES2015+ dist. To avoid any breakages, I'm including a `module` field to be used with ES2015 bundlers. It points to a dist file in ES5 with ES2015 module syntax.

Reference: https://github.com/rollup/rollup/wiki/pkg.module