### PR TITLE
1.11.0

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -129,7 +129,13 @@ export {
   // d3-queue
   Queue,
   // d3-random
-  // TODO: d3-request
+  RandomBates,
+  RandomExponential,
+  RandomIrwinHall,
+  RandomLogNormal,
+  RandomNormal,
+  RandomNumberGenerationSource,
+  RandomUniform,
   // d3-scale
   InterpolatorFactory,
   ScaleBand,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d3-ng2-service",
-  "version": "1.10.2",
+  "version": "1.11.0",
   "description": "A D3 version 4 service for use with Angular 2+.",
   "main": "index.js",
   "jsnext:main": "index.js",
@@ -74,7 +74,7 @@
     "@types/d3-collection": "1.0",
     "@types/d3-color": "1.0",
     "@types/d3-dispatch": "1.0",
-    "@types/d3-drag": "1.0",
+    "@types/d3-drag": "1.1",
     "@types/d3-dsv": "1.0",
     "@types/d3-ease": "1.0",
     "@types/d3-force": "1.0",
@@ -86,7 +86,7 @@
     "@types/d3-polygon": "1.0",
     "@types/d3-quadtree": "1.0",
     "@types/d3-queue": "3.0",
-    "@types/d3-random": "1.0",
+    "@types/d3-random": "1.1",
     "@types/d3-scale": "1.0",
     "@types/d3-selection": "1.0",
     "@types/d3-selection-multi": "1.0",
@@ -96,7 +96,7 @@
     "@types/d3-timer": "1.0",
     "@types/d3-transition": "1.0",
     "@types/d3-voronoi": "1.1",
-    "@types/d3-zoom": "1.1",
+    "@types/d3-zoom": "1.2",
     "d3-array": "1.2",
     "d3-axis": "1.0",
     "d3-brush": "1.0",
@@ -104,7 +104,7 @@
     "d3-collection": "1.0",
     "d3-color": "1.0",
     "d3-dispatch": "1.0",
-    "d3-drag": "1.0",
+    "d3-drag": "1.1",
     "d3-dsv": "1.0",
     "d3-ease": "1.0",
     "d3-force": "1.0",
@@ -116,7 +116,7 @@
     "d3-polygon": "1.0",
     "d3-quadtree": "1.0",
     "d3-queue": "3.0",
-    "d3-random": "1.0",
+    "d3-random": "1.1",
     "d3-scale": "1.0",
     "d3-selection": "1.0",
     "d3-selection-multi": "1.0",
@@ -126,7 +126,7 @@
     "d3-timer": "1.0",
     "d3-transition": "1.0",
     "d3-voronoi": "1.1",
-    "d3-zoom": "1.1"
+    "d3-zoom": "1.2"
   },
   "peerDependencies": {
     "@angular/core": "^4.0 || ^2.0 || 2.0.0-rc.5 || 2.0.0-rc.6 || 2.0.0-rc.7"


### PR DESCRIPTION
- [Dependency] Update d3-drag, d3-zoom and d3-random to their latest minor versions
- [Feature] Add newly introduced **d3-random** interfaces to exports.

Closes #55 