### PR TITLE
1.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d3-ng2-service",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "A D3 version 4 service for use with Angular 2+.",
   "main": "index.js",
   "jsnext:main": "index.js",
@@ -90,13 +90,13 @@
     "@types/d3-scale": "1.0",
     "@types/d3-selection": "1.1",
     "@types/d3-selection-multi": "1.0",
-    "@types/d3-shape": "1.2",
+    "@types/d3-shape": ">=1.2.1 <1.3.0",
     "@types/d3-time": "1.0",
     "@types/d3-time-format": "2.0",
     "@types/d3-timer": "1.0",
     "@types/d3-transition": "1.1",
     "@types/d3-voronoi": "1.1",
-    "@types/d3-zoom": "1.3",
+    "@types/d3-zoom": "1.5",
     "d3-array": "1.2",
     "d3-axis": "1.0",
     "d3-brush": "1.0",
@@ -126,7 +126,7 @@
     "d3-timer": "1.0",
     "d3-transition": "1.1",
     "d3-voronoi": "1.1",
-    "d3-zoom": "1.3"
+    "d3-zoom": "1.5"
   },
   "peerDependencies": {
     "@angular/core": "^4.0 || ^2.0 || 2.0.0-rc.5 || 2.0.0-rc.6 || 2.0.0-rc.7"


### PR DESCRIPTION
* [Feature] [d3-zoom]  Updated to minor version 1.5
* [Fix] [d3-shape] Updated dependency on @types/d3-shape to be  at least patch version 1.2.1. This was done to incorporate a bug fix for `pointRadial`.
* [Chore] Bumped minor version.

Closes  #75 