### PR TITLE
[Patch] Patch release to use min d3-voronoi definitions versionn 1.1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d3-ng2-service",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "description": "A D3 version 4 service for use with Angular 2+.",
   "main": "index.js",
   "jsnext:main": "index.js",
@@ -95,7 +95,7 @@
     "@types/d3-time-format": "2.0",
     "@types/d3-timer": "1.0",
     "@types/d3-transition": "1.1",
-    "@types/d3-voronoi": "1.1",
+    "@types/d3-voronoi": ">=1.1.7 <1.2.0",
     "@types/d3-zoom": "1.5",
     "d3-array": "1.2",
     "d3-axis": "1.0",


### PR DESCRIPTION
* bump patch release number
* As of version 1.1.7 of the definitions for d3-voronoi, a fix to the capitalization of the `halfedges`  has been applied.